### PR TITLE
docs: changed zh-CN docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A theme for [Hexo](https://hexo.io/), modified from [Landscape](https://github.com/hexojs/hexo-theme-landscape). (Work in progress)
 
-[中文文档](https://github.com/saicaca/hexo-theme-vivia/edit/main/README.zh-CN.md)
+[中文文档](README.zh-CN.md)
 
 ## Preview
 


### PR DESCRIPTION
Chinese document links seems point to links that cannot be previewed.
The previous link points to a link that non-maintainers cannot preview.

```md
[中文文档](https://github.com/saicaca/hexo-theme-vivia/edit/main/README.zh-CN.md)
```