### PR TITLE
feat: optimize article description

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,4 +1,5 @@
 <% let cover = post.photos && post.photos.length %> 
+<% let description = post.description && post.description.length %> 
 
 <article id="<%= post.layout %>-<%= post.slug %>" class="h-entry article article-type-<%= post.layout %>" itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
   <% if (is_post() || theme.home.style == 'detail') { %>
@@ -24,7 +25,11 @@
           <%- post.excerpt %>
         <% } else if (is_home() && !post.excerpt && theme.home.style != 'detail') { %>
           <div class="truncate-text">
-            <%- truncate(strip_html(post.content), {length: 500}) %>  
+            <% if(description){ %>
+              <%- strip_html(post.description) %>
+            <% } else{ %>  
+              <%- truncate(strip_html(post.content), {length: 500}) %>
+            <% } %>
           </div>
         <% } else { %>
           <%- post.content %>

--- a/source/css/_partial/comment.styl
+++ b/source/css/_partial/comment.styl
@@ -98,6 +98,7 @@
 .tk-input.el-textarea
 .tk-preview-container
 .tk-actions
+.tk-comments-no
   color: var(--neut-L90) !important
 //修复排版问题
 .tk-admin-comment-filter-type


### PR DESCRIPTION
在 Front-matter 里写上`description: xxxx`可以自定义摘要，不加就还是截取前 500 字。

这是效果图：

![加description](https://github.com/saicaca/hexo-theme-vivia/assets/103188954/809ba221-4ca6-4800-b927-9434b3c18016)

![不加description](https://github.com/saicaca/hexo-theme-vivia/assets/103188954/27bc5965-b38d-476c-a97e-124017da71df)

> ~*又是自己的需要……话说应该没人发现顺便修了个 bug 吧*~