### PR TITLE
Add toc to sidebar

### DIFF
--- a/example_config.vivia.yml
+++ b/example_config.vivia.yml
@@ -42,6 +42,7 @@ sidebar:
     normal:                # Scroll along with the page
       - profile
     sticky:                # Stick to the top of the page
+      - toc
       - category
       - tag
 #      - archive

--- a/example_zh_CN_config.vivia.yml
+++ b/example_zh_CN_config.vivia.yml
@@ -42,6 +42,7 @@ sidebar:
     normal:                # 随页面滚动的组件
       - profile
     sticky:                # 固定在页面顶部的组件
+      - toc
       - category
       - tag
 #      - archive

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -23,3 +23,4 @@ untitled: Untitled
 read_more: Read More
 article_count: article
 article_count_plural: articles
+toc: TOC

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -23,3 +23,4 @@ untitled: 无标题
 read_more: 阅读全文
 article_count: 篇文章
 article_count_plural: 篇文章
+toc: 文章目录

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -23,3 +23,4 @@ untitled: 無標題
 read_more: 閲讀全文
 article_count: 篇文章
 article_count_plural: 篇文章
+toc: 文章目錄

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -1,10 +1,10 @@
 <sidebar id="sidebar">
   <% theme.sidebar.widgets.normal.forEach(function(widget){ %>
-    <%- partial('_widget/' + widget) %>
+    <%- partial('_widget/' + widget, null, {cache: !config.relative_link && widget!='toc'}) %>
   <% }) %>
   <div class="sticky">
     <% theme.sidebar.widgets.sticky.forEach(function(widget){ %>
-      <%- partial('_widget/' + widget) %>
+      <%- partial('_widget/' + widget, null, {cache: !config.relative_link && widget!='toc'}) %>
     <% }) %>
   </div>
 </sidebar>

--- a/layout/_widget/toc.ejs
+++ b/layout/_widget/toc.ejs
@@ -1,0 +1,8 @@
+<% if (is_post()){ %>
+<div class="widget-wrap">
+  <div class="widget">
+    <h3 class="widget-title"><%= __('toc') %></h3>
+    <%- toc(page.content) %>
+  </div>
+</div>
+<% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -15,6 +15,7 @@
 %>
 <%  %>
 <html theme="dark" showBanner="true" hasBanner="<%- hasBanner %>" > 
+<link href="https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.10.2/katex.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/fontawesome.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/brands.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/solid.min.css" rel="stylesheet">
@@ -33,7 +34,7 @@
       <%- partial('_partial/navbar', null, {cache: !config.relative_link}) %>
     </div>
     <div id="sidebar-wrapper">
-      <%- partial('_partial/sidebar', null, {cache: !config.relative_link}) %>
+      <%- partial('_partial/sidebar') %>
     </div>
     <div id="content-body">
       <%- body %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -15,7 +15,6 @@
 %>
 <%  %>
 <html theme="dark" showBanner="true" hasBanner="<%- hasBanner %>" > 
-<link href="https://lf9-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.10.2/katex.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/fontawesome.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/brands.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/solid.min.css" rel="stylesheet">

--- a/source/css/_partial/sidebar.styl
+++ b/source/css/_partial/sidebar.styl
@@ -9,11 +9,12 @@
     list-style: none
     margin: 0
     ul, ol
+      list-style: none
       margin: 0 20px
     ul
       list-style: disc
     ol
-      list-style: decimal
+      list-style: none
 
 $widget-nav-link
   height: 40px


### PR DESCRIPTION
# 增加 toc 目录为 sidebar 的可选组件

Demo: http://139.159.188.217:7900/2023/10/09/hexo/hexo-tricks/

## 原理
使用 hexo 引擎内置函数 toc(), `<%- toc(page.content) %>`，位于 node_modeules/hexo/plugins/helper/toc.js。可以简单地在sidebar sticky 部分加入一个 toc，方便看长篇博客的时候快速导航。

## 改动说明
1. 修改 _partial/sidebar.ejs，渲染时加入判断，如果是toc就取消cache，防止内部获取不到page变量

2. 在 css/_partial/sidebar.styl 修改toc侧栏的 `<ol>` 样式，防止toc渲染过程中出现`<ol>`自带的数字干扰

3. 在配置模板s idebar 中增加了toc的配置选项

4. 增加 toc 对应的简中繁中翻译