### PR TITLE
feat: basic support for Waline comment system

### DIFF
--- a/example_config.vivia.yml
+++ b/example_config.vivia.yml
@@ -72,6 +72,9 @@ comment:
     path: location.pathname
     lang:
     # See also: https://github.com/imaegoo/twikoo
+  waline:
+    enable: false          # Enable Waline comment system
+    serverURL: 
 
 #Analytics
 gauges_analytics: false

--- a/example_zh_CN_config.vivia.yml
+++ b/example_zh_CN_config.vivia.yml
@@ -72,6 +72,9 @@ comment:
     path: location.pathname
     lang:
     # 详见 https://github.com/imaegoo/twikoo
+  waline:
+    enable: false          # 是否启用 Waline 评论系统
+    serverURL: 
 
 #Analytics
 gauges_analytics: false

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -104,3 +104,22 @@
       })
   </script>
   <% } %>
+
+<% if (!index && theme.comment.waline && theme.comment.waline.enable) { %>
+  <div id="wl-comment-card" class="wl-comment-card">
+    <div class="main-title-bar">
+      <div class="main-title-dot"></div>
+      <div class="main-title"><%= __('comment') %> </div>
+    </div>
+    <div id="waline"></div>
+  </div>
+  <script type="module">
+    import { init } from 'https://unpkg.com/@waline/client@v2/dist/waline.mjs';
+
+    init({
+      el: '#waline',
+      serverURL: '<%- theme.comment.waline.serverURL %>',
+      dark: 'html[theme="dark"]',
+    });
+  </script>
+<% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -44,5 +44,11 @@
     <link rel="icon" media="(prefers-color-scheme: dark)" href="<%- url_for("/images/favicon-dark-180.png") %>" sizes="180x180">
     <link rel="icon" media="(prefers-color-scheme: dark)" href="<%- url_for("/images/favicon-dark-192.png") %>" sizes="192x192">
   <% } %>
+  <% if (theme.comment.waline && theme.comment.waline.enable) { %>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@waline/client@v2/dist/waline.css"
+    />
+  <% } %>
   <%- css('css/style') %>
 </head>

--- a/source/css/_partial/comment.styl
+++ b/source/css/_partial/comment.styl
@@ -127,3 +127,21 @@
 .tk-comments-container .tk-submit
   position: relative
   left: -70px
+
+// Waline
+.wl-comment-card
+  @extend $card
+  padding: article-top-padding article-side-padding 0 article-side-padding
+  *
+    transition: none
+  .title-bar
+    margin-bottom: 24px
+  .main-title
+    @extend $main-title
+.wl-count
+  color: var(--article-text)
+.wl-panel
+  background: var(--input-field)
+:root
+  --waline-theme-color: var(--primary-btn-bg)
+  --waline-active-color: var(--primary-btn-bg)


### PR DESCRIPTION
对 [Waline](https://waline.js.org) 的简单支持

只改了一部分 CSS，可能有些地方看上去还不是很协调

支持亮、暗模式
<img width="927" alt="image" src="https://github.com/saicaca/hexo-theme-vivia/assets/55980292/eaaa3bfc-d6df-4884-a6fb-d3c3aed44f5e">
<img width="914" alt="image" src="https://github.com/saicaca/hexo-theme-vivia/assets/55980292/bf143ae5-2e44-4198-8a96-748d2ee7096d">

demo: https://blog.yfi.moe