### PR TITLE
Feat: add option to set default theme in _config.vivia.yml

### DIFF
--- a/example_config.vivia.yml
+++ b/example_config.vivia.yml
@@ -18,7 +18,7 @@ banner:
   onAllPages: true               # Display banner on all pages instead of only the home page
 
 # Appearance
-theme: dark                      # light, dark (default: dark)
+color_scheme: dark               # light, dark (default: dark)
 hue: 250                         # The hue of the theme color (e.g. red: 0, orange: 60, blue: 260, purple: 300, pink: 345)
                                  # Visit `saicaca.github.io/vivia-preview` to preview the theme color
 

--- a/example_config.vivia.yml
+++ b/example_config.vivia.yml
@@ -18,7 +18,7 @@ banner:
   onAllPages: true               # Display banner on all pages instead of only the home page
 
 # Appearance
-color_scheme: dark               # light, dark (default: dark)
+color_scheme: dark               # dark, light, auto
 hue: 250                         # The hue of the theme color (e.g. red: 0, orange: 60, blue: 260, purple: 300, pink: 345)
                                  # Visit `saicaca.github.io/vivia-preview` to preview the theme color
 

--- a/example_config.vivia.yml
+++ b/example_config.vivia.yml
@@ -18,6 +18,7 @@ banner:
   onAllPages: true               # Display banner on all pages instead of only the home page
 
 # Appearance
+theme: dark                      # light, dark (default: dark)
 hue: 250                         # The hue of the theme color (e.g. red: 0, orange: 60, blue: 260, purple: 300, pink: 345)
                                  # Visit `saicaca.github.io/vivia-preview` to preview the theme color
 

--- a/example_zh_CN_config.vivia.yml
+++ b/example_zh_CN_config.vivia.yml
@@ -18,7 +18,7 @@ banner:
   onAllPages: true               # 在所有页面上显示横幅，而不是只在首页显示
 
 # 外观
-color_scheme: dark               # light, dark
+color_scheme: dark               # dark, light, auto
 hue: 250                         # 主题色调 (例如：红: 0，橙: 60，蓝：260，紫：300，粉：345)
                                  # 可访问 `saicaca.github.io/vivia-preview` 预览颜色设置
 

--- a/example_zh_CN_config.vivia.yml
+++ b/example_zh_CN_config.vivia.yml
@@ -18,6 +18,7 @@ banner:
   onAllPages: true               # 在所有页面上显示横幅，而不是只在首页显示
 
 # 外观
+color_scheme: dark               # light, dark
 hue: 250                         # 主题色调 (例如：红: 0，橙: 60，蓝：260，紫：300，粉：345)
                                  # 可访问 `saicaca.github.io/vivia-preview` 预览颜色设置
 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -16,7 +16,7 @@
 <%
   // targetTheme: set theme to dark if not being configured to light
   let targetTheme;
-  if (theme.theme === "light") {
+  if (theme.color_scheme === "light") {
     targetTheme = "light";
   } else {
     targetTheme = "dark";

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -14,10 +14,12 @@
   }
 %>
 <%
-  // targetTheme: set theme to dark if not being configured to light
+  // targetTheme: set theme to dark if not being configured to light or auto
   let targetTheme;
   if (theme.color_scheme === "light") {
     targetTheme = "light";
+  } else if (theme.color_scheme === "auto") {
+    targetTheme = "auto";
   } else {
     targetTheme = "dark";
   }
@@ -34,6 +36,9 @@
 <body>
   <% if (theme.previewMode) { %>
     <%- partial('_widget/color') %>
+  <% } %>
+  <% if (targetTheme === "auto") { %>
+    <script src="<%- url_for("/js/auto-theme-switch.js") %>"></script>
   <% } %>
   <% if (hasBanner != "false") { %>
     <%- partial('_partial/banner') %> 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -32,13 +32,13 @@
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/solid.min.css" rel="stylesheet">
 <script src="<%- url_for("/js/color.global.min.js") %>" ></script>
 <script src="<%- url_for("/js/load-settings.js") %>" ></script>
+<% if (targetTheme === "auto") { %>
+  <script src="<%- url_for("/js/auto-theme-switch.js") %>"></script>
+<% } %>
 <%- partial('_partial/head') %>
 <body>
   <% if (theme.previewMode) { %>
     <%- partial('_widget/color') %>
-  <% } %>
-  <% if (targetTheme === "auto") { %>
-    <script src="<%- url_for("/js/auto-theme-switch.js") %>"></script>
   <% } %>
   <% if (hasBanner != "false") { %>
     <%- partial('_partial/banner') %> 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -13,8 +13,18 @@
     hasBanner = "false";
   }
 %>
+<%
+  // targetTheme: set theme to dark if not being configured to light
+  let targetTheme;
+  if (theme.theme === "light") {
+    targetTheme = "light";
+  } else {
+    targetTheme = "dark";
+  }
+%>
+
 <%  %>
-<html theme="dark" showBanner="true" hasBanner="<%- hasBanner %>" > 
+<html theme="<%- targetTheme %>" showBanner="true" hasBanner="<%- hasBanner %>" > 
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/fontawesome.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/brands.min.css" rel="stylesheet">
 <link href="https://cdn.staticfile.org/font-awesome/6.4.2/css/solid.min.css" rel="stylesheet">

--- a/source/js/auto-theme-switch.js
+++ b/source/js/auto-theme-switch.js
@@ -1,5 +1,10 @@
 function autoTheme() {
     let root = document.documentElement;
+    let theme = localStorage.getItem('theme');
+    if (theme) {
+        root.setAttribute('theme', theme);
+    } else {
     window.matchMedia('(prefers-color-scheme: light)').matches ? root.setAttribute('theme', 'light') : root.setAttribute('theme', 'dark');
+    }
 };
 autoTheme();

--- a/source/js/auto-theme-switch.js
+++ b/source/js/auto-theme-switch.js
@@ -1,0 +1,5 @@
+function autoTheme() {
+    let root = document.documentElement;
+    window.matchMedia('(prefers-color-scheme: light)').matches ? root.setAttribute('theme', 'light') : root.setAttribute('theme', 'dark');
+};
+autoTheme();


### PR DESCRIPTION
**Feature:** Allow user to set the default theme to `light`/`dark`, or use `auto` to auto switch theme based on user's system theme, when user visiting the blog for the first time.
**Note:** If user never clicked on theme-switch button in `auto` mode, then it will always follow system theme.

**Tested option:** `light`, `dark`, `auto`, `random_string`,  and commented it out.

**Justification:**
Instead of reading values from `_config.vivia.yml` and directly apply it in the ejs, this will prevent code injection from yml file. 

**Additional:**
After consideration, I add "fix the theme to light/dark once being set" behavior in `auto` mode, which I believe is better for user experience. Or the light/dark switch button will be useless since user needs to switch pages.

**Code difference:**
```
function autoTheme() {
    let root = document.documentElement;
    let theme = localStorage.getItem('theme');
    if (theme) {
        root.setAttribute('theme', theme);
    } else {
    window.matchMedia('(prefers-color-scheme: light)').matches ? root.setAttribute('theme', 'light') : root.setAttribute('theme', 'dark');
    }
};
autoTheme();
```

```
function autoTheme() {
    let root = document.documentElement;
    window.matchMedia('(prefers-color-scheme: light)').matches ? root.setAttribute('theme', 'light') : root.setAttribute('theme', 'dark');
};
autoTheme();
``` 
