### PR TITLE
Fix: banner/content align is inconsistent between long and short pages

### DIFF
--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -33,6 +33,7 @@ body
   background-size: 240px
   background-blend-mode: overlay    // TODO temporarily
   transition: background trans-style, color trans-style
+  overflow-y: hidden;
   &:before
     // TODO rotate the background
     // content: ''


### PR DESCRIPTION
If you switch pages between long and short pages, you will find out the the align is different.  
![image](https://github.com/saicaca/hexo-theme-vivia/assets/142381267/3964acc7-d5ab-4ecf-a4f7-3c9082a9d9b5)

Hide the scroll bar will solve the issue.  