### PR TITLE
Fix: tag height is not flexible

### DIFF
--- a/source/css/_extend.styl
+++ b/source/css/_extend.styl
@@ -49,8 +49,9 @@ $card-btn
 
 $text-btn
   @extend $button
-  height: 32px
-  padding: 0 12px
+  // height: 32px
+  // padding: 0 12px
+  padding: 7px 12px 7px
   font-size: 14px
 
 $tag-list-item


### PR DESCRIPTION
**Before:**  
![image](https://github.com/saicaca/hexo-theme-vivia/assets/142381267/615e0c61-c508-4f8a-8025-e0aca192be43)  
**After:**  
![image](https://github.com/saicaca/hexo-theme-vivia/assets/142381267/fbccd132-64ec-4776-8361-2b7d05f561bb)  

This commit does change the style of button a bit.   
