### PR TITLE
feat: using rel="me" to verify ownership for websites

### DIFF
--- a/layout/_widget/profile.ejs
+++ b/layout/_widget/profile.ejs
@@ -12,7 +12,7 @@
       <div class="subtitle"><%- theme.subtitle || config.subtitle %> </div>
       <div class="link-list">
         <% for(let item of theme.links) { %>
-          <a class="link-btn" href="<%- item.url %>" title="<%- item.name %>"><i class="<%- item.icon %>"></i></a>
+          <a class="link-btn" rel="me" href="<%- item.url %>" title="<%- item.name %>"><i class="<%- item.icon %>"></i></a>
         <% } %> 
       </div>  
     </div>


### PR DESCRIPTION
**Proposed change:** 
Verify the target link is presented by the same person: 
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/me

**Example scenario:** 
Mastodon profile

**Outcome:**
![image](https://github.com/saicaca/hexo-theme-vivia/assets/142381267/30ca121c-3518-49bf-95c8-0e3b9e92aa2c)
