### PR TITLE
修复第二页无法正确返回上一页问题

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -3,8 +3,7 @@
 <% }) %>
 <% if (page.total > 1){ %>
   <nav id="page-nav">
-    <!-- 在第二页时 page.prev_link 不知为何无法返回正确的链接 -->
-    <a id="prev-btn" class="page-nav-btn <% if (page.current == 1) { %>disabled<% } %>" href="<% if (page.current == 2) { %> <%- url_for('/') %> <% } else { %> <%- url_for(page.prev_link) %> <% } %> ">
+    <a id="prev-btn" class="page-nav-btn <% if (page.current == 1) { %>disabled<% } %>" href="<%- page.prev_link == "" ? url_for("/") : url_for(page.prev_link) %>">
       <i class="fa-solid fa-angle-left"></i>
     </a>
     <div id="num-bar">


### PR DESCRIPTION
造成原因：当上一页为首页时page.prev_link为空，而url_for不接受空字符串