### PR TITLE
fix(css): Ensure back-to-top button does not block other elements

### DIFF
--- a/source/css/_partial/back-to-top.styl
+++ b/source/css/_partial/back-to-top.styl
@@ -4,6 +4,7 @@
     position: absolute
     right: 0
     top: 0
+    pointer-events: none;
     @media mq-mobile
         display: none
     @media mq-tablet
@@ -21,6 +22,7 @@
     opacity: 1
     transition: background trans-style, opacity trans-style, transform trans-style
     cursor: pointer
+    pointer-events: auto;
     transform: translate(80px)
     i
         font-size: 24px


### PR DESCRIPTION
- Added pointer-events: none to .back-to-top-wrapper to make it transparent to click events.
- Enabled pointer-events for .back-to-top-button within the wrapper to ensure functionality.
- Ensured the back-to-top button remains functional and does not interfere with other clickable elements.